### PR TITLE
Allow Peroxaan MC Bot to ratio more than once/15 seconds

### DIFF
--- a/src/ratio_handler.py
+++ b/src/ratio_handler.py
@@ -19,7 +19,7 @@ async def handle_ratio(message: discord.Message, db: Database, is_bot: bool):
         last_ratio: datetime.date = timeouts[message.author.id]
         seconds_since_last_ratio: float = (current_date - last_ratio).total_seconds()
         print(seconds_since_last_ratio)
-        if seconds_since_last_ratio < 15:
+        if seconds_since_last_ratio < 15 and message.author.id != 392460808455454730:
             await message.add_reaction('💀')
             return
     except KeyError:


### PR DESCRIPTION
If two people are in the MC server, and one tries to ratio, then the other tries to ratio, the second one will get the :skull: because it's all coming from the same discord account (the Peroxaan MC Bot)

![image](https://user-images.githubusercontent.com/29960599/184548148-33bee78c-f8e4-4990-9f34-579bfe7fa556.png)
